### PR TITLE
use dimensions instead of float for pathWidth

### DIFF
--- a/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
+++ b/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
@@ -126,7 +126,7 @@ public class PathView extends View implements SvgUtils.AnimationStepListener {
         try {
             if (a != null) {
                 paint.setColor(a.getColor(R.styleable.PathView_pathColor, 0xff00ff00));
-                paint.setStrokeWidth(a.getFloat(R.styleable.PathView_pathWidth, 8.0f));
+                paint.setStrokeWidth(a.getDimensionPixelSize(R.styleable.PathView_pathWidth, 8));
                 svgResourceId = a.getResourceId(R.styleable.PathView_svg, 0);
             }
         } finally {

--- a/android-pathview/src/main/res/values/attrs.xml
+++ b/android-pathview/src/main/res/values/attrs.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <declare-styleable name="PathView">
-    <attr name="pathColor"
-        format="color"/>
-    <attr name="pathWidth"
-        format="float"/>
-    <attr name="svg"
-        format="reference"/>
+    <attr name="pathColor" format="color|reference"/>
+    <attr name="pathWidth" format="dimension|reference"/>
+    <attr name="svg" format="reference"/>
   </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/activity_second.xml
+++ b/sample/src/main/res/layout/activity_second.xml
@@ -13,6 +13,6 @@
         android:layout_height="350dp"
         app:svg="@raw/monitor"
         app:pathColor="@android:color/white"
-        app:pathWidth="2"/>
+        app:pathWidth="2dp"/>
 
 </LinearLayout>

--- a/sample/src/main/res/layout/fragment_issues.xml
+++ b/sample/src/main/res/layout/fragment_issues.xml
@@ -10,7 +10,7 @@
         android:id="@+id/pathView"
         android:layout_width="58dp"
         app:pathColor="@android:color/holo_red_dark"
-        app:pathWidth="2"
+        app:pathWidth="2dp"
         app:svg="@raw/issues"
         android:layout_height="58dp"/>
 

--- a/sample/src/main/res/layout/fragment_logout.xml
+++ b/sample/src/main/res/layout/fragment_logout.xml
@@ -10,7 +10,7 @@
         android:id="@+id/pathView"
         android:layout_width="150dp"
         app:pathColor="@android:color/black"
-        app:pathWidth="1"
+        app:pathWidth="1dp"
         android:layout_gravity="center"
         app:svg="@raw/logout"
         android:layout_height="150dp"/>

--- a/sample/src/main/res/layout/fragment_settings.xml
+++ b/sample/src/main/res/layout/fragment_settings.xml
@@ -10,7 +10,7 @@
         android:id="@+id/pathView"
         android:layout_width="match_parent"
         app:pathColor="@android:color/white"
-        app:pathWidth="10"
+        app:pathWidth="10dp"
         app:svg="@raw/settings"
         android:layout_height="match_parent"/>
 


### PR DESCRIPTION
Just corrected `pathWidth` to accept dimensions instead of float.