### PR TITLE
[squid:S2583] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
+++ b/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
@@ -222,7 +222,7 @@ public class PathView extends View implements SvgUtils.AnimationStepListener {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        if(mTempBitmap==null || (mTempBitmap!=null && (mTempBitmap.getWidth()!=canvas.getWidth()||mTempBitmap.getHeight()!=canvas.getHeight()) ))
+        if(mTempBitmap==null || (mTempBitmap.getWidth()!=canvas.getWidth()||mTempBitmap.getHeight()!=canvas.getHeight()) )
         {
             mTempBitmap = Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
             mTempCanvas = new Canvas(mTempBitmap);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - “Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.
Ayman Abdelghany.