### PR TITLE
[squid:S00122] Statements should be on separate lines

### DIFF
--- a/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
+++ b/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
@@ -599,12 +599,14 @@ public class PathView extends View implements SvgUtils.AnimationStepListener {
 
             @Override
             public void onAnimationStart(Animator animation) {
-                if (listenerStart != null) listenerStart.onAnimationStart();
+                if (listenerStart != null) 
+                    listenerStart.onAnimationStart();
             }
 
             @Override
             public void onAnimationEnd(Animator animation) {
-                if (animationEnd != null) animationEnd.onAnimationEnd();
+                if (animationEnd != null) 
+                    animationEnd.onAnimationEnd();
             }
 
             @Override
@@ -792,12 +794,14 @@ public class PathView extends View implements SvgUtils.AnimationStepListener {
 
             @Override
             public void onAnimationStart(Animator animation) {
-                if (listenerStart != null) listenerStart.onAnimationStart();
+                if (listenerStart != null) 
+                    listenerStart.onAnimationStart();
             }
 
             @Override
             public void onAnimationEnd(Animator animation) {
-                if (animationEnd != null) animationEnd.onAnimationEnd();
+                if (animationEnd != null) 
+                    animationEnd.onAnimationEnd();
             }
 
             @Override

--- a/android-pathview/src/main/java/com/eftimoff/androipathview/SvgUtils.java
+++ b/android-pathview/src/main/java/com/eftimoff/androipathview/SvgUtils.java
@@ -58,7 +58,8 @@ public class SvgUtils {
      * @param svgResource int resource id of the svg.
      */
     public void load(Context context, int svgResource) {
-        if (mSvg != null) return;
+        if (mSvg != null) 
+            return;
         try {
             mSvg = SVG.getFromResource(context, svgResource);
             mSvg.setDocumentPreserveAspectRatio(PreserveAspectRatio.UNSCALED);
@@ -129,7 +130,8 @@ public class SvgUtils {
      * @param canvas      The canvas to be drawn.
      */
     private void rescaleCanvas(int width, int height, float strokeWidth, Canvas canvas) {
-        if (mSvg == null) return;
+        if (mSvg == null) 
+            return;
         final RectF viewBox = mSvg.getDocumentViewBox();
 
         final float scale = Math.min(width


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00122 - “Statements should be on separate lines”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00122

Please let me know if you have any questions.
Ayman Abdelghany.