### PR TITLE
[squid:S1244] Floating point numbers should not be tested for equality

### DIFF
--- a/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
+++ b/android-pathview/src/main/java/com/eftimoff/androipathview/PathView.java
@@ -256,7 +256,7 @@ public class PathView extends View implements SvgUtils.AnimationStepListener {
      * @param canvas Draw to this canvas.
      */
     private void fillAfter(final Canvas canvas) {
-        if (svgResourceId != 0 && fillAfter && progress == 1f) {
+        if (svgResourceId != 0 && fillAfter && Math.abs(progress - 1f) < 0.00000001) {
             svgUtils.drawSvgAfter(canvas, width, height);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1244 - “Floating point numbers should not be tested for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1244

Please let me know if you have any questions.
Ayman Abdelghany.